### PR TITLE
bugfix: Issue #12

### DIFF
--- a/lib/otp_field.dart
+++ b/lib/otp_field.dart
@@ -176,11 +176,19 @@ class _OTPTextFieldState extends State<OTPTextField> {
           if (!_pin.contains(null) &&
               !_pin.contains('') &&
               currentPin.length == widget.length) {
-            widget.onCompleted!(currentPin);
+            var onCompleted = widget.onCompleted;
+            if(onCompleted != null) {
+              onCompleted(currentPin);
+            }
+            // widget.onCompleted!(currentPin);
           }
 
           // Call the `onChanged` callback function
-          widget.onChanged!(currentPin);
+          var onChanged = widget.onChanged;
+          if(onChanged != null) {
+            onChanged(currentPin);
+          }
+          // widget.onChanged!(currentPin);
         },
       ),
     );
@@ -222,10 +230,18 @@ class _OTPTextFieldState extends State<OTPTextField> {
     if (!_pin.contains(null) &&
         !_pin.contains('') &&
         currentPin.length == widget.length) {
-      widget.onCompleted!(currentPin);
+      var onCompleted = widget.onCompleted;
+      if(onCompleted != null) {
+        onCompleted(currentPin);
+      }
+      // widget.onCompleted!(currentPin);
     }
 
     // Call the `onChanged` callback function
-    widget.onChanged!(currentPin);
+    var onChanged = widget.onChanged;
+    if(onChanged != null) {
+      onChanged(currentPin);
+    }
+    // widget.onChanged!(currentPin);
   }
 }


### PR DESCRIPTION

### Null check operator used on a null value iamvivekkaushik/OTPTextField#12

File: `lib/otp_field.dart`

on `line 183` and `line 229`
```diff
- widget.onChanged!(currentPin);

+ var onChanged = widget.onChanged;
+ if(onChanged != null) {
+   onChanged(currentPin);
+ }
```

on `line 179` and `line 225`
```diff
- widget.onCompleted!(currentPin);

+ var onCompleted = widget.onCompleted;
+      if(onCompleted != null) {
+        onCompleted(currentPin);
+      }
```