### PR TITLE
Fix 'null check operator used on a null value cast error' if onChanged or onCompleted is null

### DIFF
--- a/lib/otp_field.dart
+++ b/lib/otp_field.dart
@@ -175,12 +175,13 @@ class _OTPTextFieldState extends State<OTPTextField> {
           // Call the `onCompleted` callback function provided
           if (!_pin.contains(null) &&
               !_pin.contains('') &&
-              currentPin.length == widget.length) {
+              (currentPin.length == widget.length) &&
+              widget.onCompleted != null) {
             widget.onCompleted!(currentPin);
           }
 
           // Call the `onChanged` callback function
-          widget.onChanged!(currentPin);
+          if (widget.onChanged != null) widget.onChanged!(currentPin);
         },
       ),
     );


### PR DESCRIPTION
Flutter throws "_CastError (Null check operator used on a null value)"﻿ if onChanged or onCompleted callbacks is not defined when initializing the OTPTextField widget.
This fix checks if the callbacks functions are defined before calling it. 
