### PR TITLE
Add textCapitalization

### DIFF
--- a/lib/otp_field.dart
+++ b/lib/otp_field.dart
@@ -33,6 +33,8 @@ class OTPTextField extends StatefulWidget {
   /// show the error border or not
   final bool hasError;
 
+  final TextCapitalization textCapitalization;
+
   /// The style to use for the text being edited.
   final TextStyle style;
 
@@ -78,6 +80,7 @@ class OTPTextField extends StatefulWidget {
     this.keyboardType = TextInputType.number,
     this.style = const TextStyle(),
     this.outlineBorderRadius: 10,
+    this.textCapitalization = TextCapitalization.none,
     this.textFieldAlignment = MainAxisAlignment.spaceBetween,
     this.obscureText = false,
     this.fieldStyle = FieldStyle.underline,
@@ -177,6 +180,7 @@ class _OTPTextFieldState extends State<OTPTextField> {
       child: TextField(
         controller: _textControllers[index],
         keyboardType: widget.keyboardType,
+        textCapitalization: widget.textCapitalization,
         textAlign: TextAlign.center,
         style: widget.style,
         inputFormatters: widget.inputFormatter,


### PR DESCRIPTION
To enable the following feature: 

https://stackoverflow.com/questions/49238908/flutter-textfield-value-always-uppercase-debounce

It's not possible to always use upper case characters. 🎉