### PR TITLE
fix: remove maxLines from text field to allow pasting functionality work

### DIFF
--- a/lib/otp_field.dart
+++ b/lib/otp_field.dart
@@ -186,7 +186,6 @@ class _OTPTextFieldState extends State<OTPTextField> {
         textAlign: TextAlign.center,
         style: widget.style,
         inputFormatters: widget.inputFormatter,
-        maxLength: 1,
         focusNode: _focusNodes[index],
         obscureText: widget.obscureText,
         decoration: InputDecoration(


### PR DESCRIPTION
This won't cause any issues of multiple text showing in one field because the code already handles that in the _handlePasting method.