### PR TITLE
UPPERCASE keyboard in an OTPTextField widget #50

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ OTPTextField(
     fontSize: 17
   ),
   textFieldAlignment: MainAxisAlignment.spaceAround,
+  textCapitalization: TextCapitalization.characters,
   fieldStyle: FieldStyle.underline,
   onCompleted: (pin) {
     print("Completed: " + pin);

--- a/lib/otp_field.dart
+++ b/lib/otp_field.dart
@@ -6,6 +6,9 @@ import 'package:otp_text_field/style.dart';
 class OTPTextField extends StatefulWidget {
   /// TextField Controller
   final OtpFieldController? controller;
+  
+  /// TextCapitalization
+  final TextCapitalization? textCapitalization;
 
   /// Number of the OTP Fields
   final int length;
@@ -69,6 +72,7 @@ class OTPTextField extends StatefulWidget {
     this.controller,
     this.fieldWidth = 30,
     this.spaceBetween = 0,
+    this.textCapitalization = TextCapitalization.none,
     this.otpFieldStyle,
     this.hasError = false,
     this.keyboardType = TextInputType.number,
@@ -187,6 +191,7 @@ class _OTPTextFieldState extends State<OTPTextField> {
         style: widget.style,
         inputFormatters: widget.inputFormatter,
         maxLength: 1,
+        textCapitalization: widget.textCapitalization!,
         focusNode: _focusNodes[index],
         obscureText: widget.obscureText,
         decoration: InputDecoration(


### PR DESCRIPTION
If I want to use an uppercase keyboard in an OTPTextField widget in Flutter, I can use the textInputAction and textCapitalization properties to customize the keyboard behavior. Here's an example:

```
OTPTextField(
  length: 6,
  width: MediaQuery.of(context).size.width,
  fieldWidth: 50,
  style: TextStyle(fontSize: 20),
  textFieldAlignment: MainAxisAlignment.spaceAround,
  fieldStyle: FieldStyle.underline,
  onCompleted: (pin) {
    // Do something with the entered OTP.
  },
  textInputAction: TextInputAction.done,
  textCapitalization: TextCapitalization.characters,
),
```
In the above example, the textInputAction property is set to TextInputAction.done, which will display a "Done" button on the keyboard, and the textCapitalization property is set to TextCapitalization.characters, which will force the keyboard to display uppercase letters.